### PR TITLE
fix ValueError exception when compression is used

### DIFF
--- a/mara_storage/shell.py
+++ b/mara_storage/shell.py
@@ -70,14 +70,14 @@ def __(alias: str, file_name: str, compression: Compression = Compression.NONE):
 @write_file_command.register(storages.LocalStorage)
 def __(storage: storages.LocalStorage, file_name: str, compression: Compression = Compression.NONE):
     if compression not in [Compression.NONE]:
-        ValueError(f'Only compression NONE is supported from storage type "{storage.__class__.__name__}"')
+        raise ValueError(f'Only compression NONE is supported from storage type "{storage.__class__.__name__}"')
     return 'cat - > ' + shlex.quote(str( (storage.base_path / file_name).absolute() ))
 
 
 @write_file_command.register(storages.GoogleCloudStorage)
 def __(storage: storages.GoogleCloudStorage, file_name: str, compression: Compression = Compression.NONE):
     if compression not in [Compression.NONE, Compression.GZIP]:
-        ValueError(f'Only compression NONE and GZIP is supported from storage type "{storage.__class__.__name__}"')
+        raise ValueError(f'Only compression NONE and GZIP is supported from storage type "{storage.__class__.__name__}"')
     return ('gsutil cp '
             + ('-Z ' if compression == Compression.GZIP else '')
             + '- '


### PR DESCRIPTION
A `ValueError` exception is not thrown in some cases in `shell.py` when using parameter `compression`