### PR TITLE
Add zip compression to write file to local storage

### DIFF
--- a/mara_storage/shell.py
+++ b/mara_storage/shell.py
@@ -80,7 +80,8 @@ def __(storage: storages.LocalStorage, file_name: str, compression: Compression 
         else:
             zip_file_name = full_path.name
 
-        return f'(zip {shlex.quote(str( full_path ))} - && printf "@ -\\n@={shlex.quote(zip_file_name)}\\n" | zipnote -w {shlex.quote(str( full_path ))})'
+        return f'(zip {shlex.quote(str( full_path ))} - \\\n' \
+               + f'     && printf "@ -\\n@={shlex.quote(zip_file_name)}\\n" | zipnote -w {shlex.quote(str( full_path ))})'
     else:
         return 'cat - > ' + shlex.quote(str( full_path ))
 

--- a/mara_storage/shell.py
+++ b/mara_storage/shell.py
@@ -6,7 +6,7 @@ Shell command generation for
 from functools import singledispatch
 import shlex
 
-from mara_storage.compression import Compression, uncompressor
+from mara_storage.compression import Compression, uncompressor, file_extension
 from mara_storage import storages
 
 
@@ -69,9 +69,20 @@ def __(alias: str, file_name: str, compression: Compression = Compression.NONE):
 
 @write_file_command.register(storages.LocalStorage)
 def __(storage: storages.LocalStorage, file_name: str, compression: Compression = Compression.NONE):
-    if compression not in [Compression.NONE]:
-        raise ValueError(f'Only compression NONE is supported from storage type "{storage.__class__.__name__}"')
-    return 'cat - > ' + shlex.quote(str( (storage.base_path / file_name).absolute() ))
+    if compression not in [Compression.NONE, Compression.ZIP]:
+        raise ValueError(f'Only compression NONE and ZIP is supported from storage type "{storage.__class__.__name__}"')
+
+    full_path = (storage.base_path / file_name).absolute()
+    if compression == Compression.ZIP:
+        # the name which shall be used in the zip file
+        if full_path.suffix[1:] == file_extension(compression):
+            zip_file_name = full_path.stem
+        else:
+            zip_file_name = full_path.name
+
+        return f'(zip {shlex.quote(str( full_path ))} - && printf "@ -\\n@={shlex.quote(zip_file_name)}\\n" | zipnote -w {shlex.quote(str( full_path ))})'
+    else:
+        return 'cat - > ' + shlex.quote(str( full_path ))
 
 
 @write_file_command.register(storages.GoogleCloudStorage)

--- a/tests/test_local_storage.py
+++ b/tests/test_local_storage.py
@@ -80,16 +80,26 @@ def test_read_file_command(storage: object):
 def test_write_file_command(storage: object):
     assert isinstance(storage, storages.LocalStorage)
 
+    # prepare
     file_path = storage.base_path / TEST_WRITE_FILE_NAME
+    compressions = [
+        Compression.NONE,
+        Compression.ZIP]
 
     assert storage.base_path
-    command = shell.write_file_command(storage, file_name=TEST_WRITE_FILE_NAME)
-    assert command
 
-    (exitcode, _) = subprocess.getstatusoutput(f'echo "{TEST_CONTENT}" | {command}')
-    assert exitcode == 0
+    # test
+    for compression in compressions:
+        print(f'Test compression: {compression}')
+        file_extension = compression_file_extension(compression)
+        file_extension = f'.{file_extension}' if file_extension else ''
+        command = shell.write_file_command(storage, file_name=f'{TEST_WRITE_FILE_NAME}{file_extension}', compression=compression)
+        assert command
 
-    assert file_path.is_file()
+        (exitcode, _) = subprocess.getstatusoutput(f'echo "{TEST_CONTENT}" | {command}')
+        assert exitcode == 0
+
+        assert file_path.is_file()
 
 
 def test_delete_file_command(storage: object):


### PR DESCRIPTION
This adds the possibility to write the stdin to local storage (`shell.write_file_command`) with zip compression.

**Notes:**
- it is necessary to set the name in the zip file with `zipnote`. Otherwise it would be named `-`
- when the command which pipes content fails, the zip file will still be created with the content which has been delivered already