### PR TITLE
fix support initializing the StorageClient from storage alias

### DIFF
--- a/mara_storage/client.py
+++ b/mara_storage/client.py
@@ -7,7 +7,7 @@ from mara_storage import storages
 
 class StorageClient():
     """A base class for a storage client"""
-    def __new__(cls, storage: object):
+    def __new__(cls, storage: t.Union[str, storages.Storage]):
         if storage is None:
             raise ValueError('Please provide the storage prameter')
 
@@ -17,8 +17,11 @@ class StorageClient():
         else:
             return super(StorageClient, cls).__new__(cls)
 
-    def __init__(self, storage: object):
-        self._storage = storage
+    def __init__(self, storage: t.Union[str, storages.Storage]):
+        if isinstance(storage, str):
+            self._storage = storages.storage(storage)
+        else:
+            self._storage = storage
 
     def last_modification_timestamp(self, path: str) -> datetime.datetime:
         """Returns the last modification timestamp for a object (path or file) on a storage"""


### PR DESCRIPTION
I found an issue with the StorageClient: The storage client needs to be initialized from the Storage object but does not support to be initialized via an storage_alias. This breaks [mara_pipelines.parallel_tasks.files._ParallelRead](https://github.com/mara/mara-pipelines/blob/master/mara_pipelines/parallel_tasks/files.py#L70-L73).

With this fix _ParallelRead will work correct again.

I tested this in my dev environment.