### PR TITLE
fix exceptions without `raise` keyword

### DIFF
--- a/mara_storage/compression.py
+++ b/mara_storage/compression.py
@@ -33,7 +33,7 @@ def compressor(compression: Compression) -> str:
         The compress command without the files to be compressed
     """
     if compression not in [Compression.ZIP, Compression.GZIP, Compression.TAR_GZIP]:
-        ValueError('The arg compression must be of enum value ZIP, GZIP or TAR_GZIP')
+        raise ValueError('The arg compression must be of enum value ZIP, GZIP or TAR_GZIP')
 
     return {Compression.ZIP: 'zip -',
             Compression.GZIP: 'gzip -c',

--- a/mara_storage/shell.py
+++ b/mara_storage/shell.py
@@ -215,7 +215,7 @@ def __(storage: storages.LocalStorage, file_name: str, force: bool = True, recur
 @delete_file_command.register(storages.SftpStorage)
 def __(storage: storages.SftpStorage, file_name: str, force: bool = True, recursive: bool = False):
     if not force:
-        ValueError(f'Only force=True is supported from storage type "{storage.__class__.__name__}"')
+        raise ValueError(f'Only force=True is supported from storage type "{storage.__class__.__name__}"')
 
     return ((f'sshpass -p {storage.password} ' if storage.password else '')
             + 'sftp'


### PR DESCRIPTION
Some `ValueError` exceptions where used without preceeding keyword `raise`